### PR TITLE
feat: 相対時刻対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ interface Video {
   url: string;
   timeout: number;
   at?: string;
+  base?: "system" | "relative";
 }
 ```
 
@@ -79,6 +80,7 @@ interface Video {
 | url        | 測定対象の動画の URL                                                          |
 | timeout    | 測定し続ける時間 (秒)                                                         |
 | at         | 測定を開始する時刻 (時:分, 正規表現 `^[0-5][0-9]:[0-5][0-9]$` に整合する形式) |
+| base       | 時刻の基準 (デフォルト: システム時刻 `system`)                                |
 
 ## Docker Hub に公開する方法
 

--- a/botconfig.schema.json
+++ b/botconfig.schema.json
@@ -29,6 +29,24 @@
             "title": "測定を開始する時刻 (分:秒)",
             "type": "string",
             "pattern": "^[0-5][0-9]:[0-5][0-9]$"
+          },
+          "base": {
+            "title": "時刻の基準",
+            "description": "`at` プロパティを使用しない場合、無視されます",
+            "type": "string",
+            "anyOf": [
+              {
+                "title": "システム時刻",
+                "type": "string",
+                "const": "system"
+              },
+              {
+                "title": "実行開始のタイミングからの相対時刻",
+                "type": "string",
+                "const": "relative"
+              }
+            ],
+            "default": "system"
           }
         },
         "additionalProperties": false

--- a/start.ts
+++ b/start.ts
@@ -87,13 +87,26 @@ const autoPlay = async (driver?: WebDriver) => {
   job(
     schedule,
     async () => {
-      for (const { url, timeout, at } of playlist) {
-        while (
-          new Date().toLocaleTimeString(undefined, {
-            minute: "2-digit",
-            second: "2-digit",
-          }) < at
-        ) {
+      const startedAt = new Date();
+      for (const { url, timeout, at, base = "system" } of playlist) {
+        const now = {
+          system() {
+            return new Date().toLocaleTimeString(undefined, {
+              minute: "2-digit",
+              second: "2-digit",
+            });
+          },
+          relative() {
+            return new Date(
+              Date.now() - startedAt.valueOf()
+            ).toLocaleTimeString(undefined, {
+              timeZone: "UTC",
+              minute: "2-digit",
+              second: "2-digit",
+            });
+          },
+        }[base as "system" | "relative"];
+        while (now() < at) {
           await new Promise((resolve) => setTimeout(resolve, 100));
         }
         try {


### PR DESCRIPTION
`at` プロパティを使用したとき、実行開始のタイミングからの相対時刻を参照できるようにします。`base` プロパティに `relative` と指定することによって実現できるようになります。デフォルトではシステム時刻 (`system`) を参照します。`at` プロパティを使用しない場合、無視されます。


例えば

```json
{
  "$schema": "https://raw.githubusercontent.com/videomark/sodium-bot/master/botconfig.schema.json",
  "schedule": "*/10 * * * *",
  "playlist": [
    {
      "base": "relative",
      "at": "00:00",
      "timeout": 240,
      "url": "https://abema.tv/now-on-air/abema-news"
    },
    {
      "base": "relative",
      "at": "05:00",
      "timeout": 240,
      "url": "https://www.youtube.com/watch?v=0eKVizvYSUQ"
    }
  ]
}
```

これは

- \*時0～50分まで10分おきにABEMAの計測
- \*時5～55分まで10分おきにYouTubeの計測

をそれぞれ交互に繰り返し行うことを意味します。
