### PR TITLE
最新QoE問い合わせ停止

### DIFF
--- a/setup.ts
+++ b/setup.ts
@@ -92,6 +92,7 @@ const setSessionId = async (driver: WebDriver, sessionId: string) => {
   await driver.get(
     new URL(
       `?${new URLSearchParams({
+        bot: "true",
         session_id: sessionId,
       })}#/settings`,
       url


### PR DESCRIPTION
resolved https://github.com/webdino/sodium/issues/936

- 自動計測端末での最新QoE問い合わせ停止
