### PR TITLE
VideoMark v2.7.1+ で計測できない問題の修正

### DIFF
--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -21,7 +21,7 @@ RUN \
   CHROME_MAJOR_VERSION=$(google-chrome --version | sed -E "s/.* ([0-9]+)(\.[0-9]+){3}.*/\1/") \
   && CHROME_DRIVER_VERSION=$(curl -sSfL "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_${CHROME_MAJOR_VERSION}") \
   && curl \
-  -sSfL "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${CHROME_DRIVER_VERSION}/linux64/chromedriver-linux64.zip" \
+  -sSfL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_DRIVER_VERSION}/linux64/chromedriver-linux64.zip" \
   -o chromedriver.zip \
   && unzip chromedriver.zip chromedriver-linux64/chromedriver \
   && install chromedriver-linux64/chromedriver /usr/local/bin/ \

--- a/setup.ts
+++ b/setup.ts
@@ -64,10 +64,10 @@ const agreeToTerms = async (driver: WebDriver) => {
     .findElement(
       By.xpath(
         `\
-  //button[*/@aria-label="プライバシーを尊重します"]
-| //button[*/@aria-label="We respect your privacy"]`
-      )
-    )
+  //button[@aria-label="プライバシーを尊重します"]
+| //button[@aria-label="We respect your privacy"]`,
+      ),
+  )
     .click();
   await driver
     .findElement(


### PR DESCRIPTION
前提:

- VideoMark v2.7.1+

エラーログ:

```
/home/watanabe/sodium-bot/node_modules/selenium-webdriver/lib/error.js:524
    let err = new ctor(data.message)
              ^
NoSuchElementError: no such element: Unable to locate element: {"method":"xpath","selector":"  //button[*/@aria-label="プライバシーを尊重します"]
| //button[*/@aria-label="We respect your privacy"]"}
  (Session info: chrome=122.0.6261.128)
    at Object.throwDecodedError (/home/watanabe/sodium-bot/node_modules/selenium-webdriver/lib/error.js:524:15)
    at parseHttpResponse (/home/watanabe/sodium-bot/node_modules/selenium-webdriver/lib/http.js:587:13)
```

VideoMark v2.7.1 以降でオンボーディングページの構造が変わりました。それに伴い計測が開始されない問題がありました。XPathの記述を変更することでその問題を修正します。
